### PR TITLE
商品情報編集の作成

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,8 @@
 class ItemsController < ApplicationController
   before_action :set_item , except: [:index, :new, :create]
   before_action :authenticate_user!, except: [:index, :show]
-  # before_aciton :item_params , only: [:new, :create, :edit]
+  before_action :return_signin, only: [:new, :edit] 
+  before_action :another_top, only: [:edit ] 
 
   def index
     @items = Item.all.order("created_at DESC")
@@ -23,8 +24,17 @@ class ItemsController < ApplicationController
   def show
   end
 
-  # def edit
-  # end
+  def edit
+  end
+
+  def update
+    @item.update(item_params)
+    if @item.save
+      redirect_to item_path
+    else
+      render :edit
+    end
+  end
 
   # def destroy
   # end
@@ -40,4 +50,17 @@ class ItemsController < ApplicationController
   def set_item
     @item = Item.find(params[:id])
   end
+
+  def return_signin
+    unless user_signed_in?
+      redirect_to new_user_session_path
+    end
+  end
+
+  def another_top
+    if current_user.id != @item.user[:id] || @item.order != nil
+      redirect_to root_path
+    end
+  end
+
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -28,8 +28,7 @@ class ItemsController < ApplicationController
   end
 
   def update
-    @item.update(item_params)
-    if @item.save
+    if @item.update(item_params)
       redirect_to item_path
     else
       render :edit
@@ -58,7 +57,7 @@ class ItemsController < ApplicationController
   end
 
   def another_top
-    if current_user.id != @item.user[:id] || @item.order != nil
+    if current_user.id != @item.user[:id]  #|| @item.order != nil
       redirect_to root_path
     end
   end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -23,7 +23,7 @@ class Item < ApplicationRecord
   validates :image       , presence: true
 
   belongs_to :user
-  has_one :order
+  # has_one :order
 
 
 

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -23,7 +23,7 @@ class Item < ApplicationRecord
   validates :image       , presence: true
 
   belongs_to :user
-  # has_one :order
+  has_one :order
 
 
 

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -7,11 +7,10 @@ app/assets/stylesheets/items/new.css %>
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with local: true do |f| %>
+    <%= form_with model: @item,local: true do |f| %>
 
     <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
-    <%# render 'shared/error_messages', model: f.object %>
-    <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
+    <%= render 'shared/error_messages', model: f.object %>
 
     <%# 商品画像 %>
     <div class="img-upload">
@@ -23,23 +22,24 @@ app/assets/stylesheets/items/new.css %>
         <p>
           クリックしてファイルをアップロード
         </p>
-        <%= f.file_field :hoge, id:"item-image" %>
+        <%= f.file_field :image, id:"item-image" %>
       </div>
     </div>
     <%# /商品画像 %>
+
     <%# 商品名と商品説明 %>
     <div class="new-items">
       <div class="weight-bold-text">
         商品名
         <span class="indispensable">必須</span>
       </div>
-      <%= f.text_area :hoge, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
+      <%= f.text_area :item_name, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
       <div class="items-explain">
         <div class="weight-bold-text">
           商品の説明
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_area :hoge, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
+        <%= f.text_area :explain, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
       </div>
     </div>
     <%# /商品名と商品説明 %>
@@ -52,12 +52,12 @@ app/assets/stylesheets/items/new.css %>
           カテゴリー
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-category"}) %>
+        <%= f.collection_select(:category_id, Category.all, :id, :name, {}, {class:"select-box", id:"item-category"}) %>
         <div class="weight-bold-text">
           商品の状態
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-sales-status"}) %>
+        <%= f.collection_select(:state_id, State.all, :id, :name, {}, {class:"select-box", id:"item-sales-status"}) %>
       </div>
     </div>
     <%# /商品の詳細 %>
@@ -73,17 +73,17 @@ app/assets/stylesheets/items/new.css %>
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+        <%= f.collection_select(:postfee_id, Postfee.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-prefecture"}) %>
+        <%= f.collection_select(:area_id, Area.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %>
         <div class="weight-bold-text">
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        <%= f.collection_select(:shipdate_id, Shipdate.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
       </div>
     </div>
     <%# /配送について %>
@@ -101,7 +101,7 @@ app/assets/stylesheets/items/new.css %>
             <span class="indispensable">必須</span>
           </div>
           <span class="sell-yen">¥</span>
-          <%= f.text_field :hoge, class:"price-input", id:"item-price", placeholder:"例）300" %>
+          <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %>
         </div>
         <div class="price-content">
           <span>販売手数料 (10%)</span>
@@ -141,7 +141,7 @@ app/assets/stylesheets/items/new.css %>
     <%# 下部ボタン %>
     <div class="sell-btn-contents">
       <%= f.submit "変更する" ,class:"sell-btn" %>
-      <%=link_to 'もどる', "#", class:"back-btn" %>
+      <%=link_to 'もどる', item_path(@item), class:"back-btn" %>
     </div>
     <%# /下部ボタン %>
   </div>

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -1,4 +1,4 @@
-<%# cssは商品出品のものを併用しています。
+<%# cssは商品出品のものを併用中
 app/assets/stylesheets/items/new.css %>
 
 <div class="items-sell-contents">
@@ -8,8 +8,7 @@ app/assets/stylesheets/items/new.css %>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
     <%= form_with model: @item,local: true do |f| %>
-
-    <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
+     
     <%= render 'shared/error_messages', model: f.object %>
 
     <%# 商品画像 %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -137,11 +137,11 @@
                 <%= image_tag item.image, class: "item-img" %>
                 
                 <%# 選択商品が売れて購入記録存在するとsold out表示 %>
-                <% if item.order != nil %> 
-                  <div class='sold-out'>
-                    <span>Sold Out!!</span>
-                  </div>
-                <% end %>
+                <%# <% if item.order != nil %> 
+                  <%# <div class='sold-out'> %>
+                    <%# <span>Sold Out!!</span>
+                  </div> %>
+                 <%# end  %>
               </div>
               <div class='item-info'>
                 <h3 class='item-name'>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -128,7 +128,7 @@
     </div>
     <ul class='item-lists'>
 
-       <%# 商品がある場合、以下に全商品を一般公開 %>
+        <%# 商品がある場合、以下に全商品を一般公開 %>
       <% if @items != nil %>
         <% @items.each do |item| %>
            <li class='list'>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -6,11 +6,17 @@
     <h2 class="name">
       <%= @item.item_name %>
     </h2>
-    <%# 選択した出品商品の詳細 %>
+
+     <%# 選択した出品商品の詳細 %>
     <% if @item != nil  %>
       <div class="item-img-content">
         <%= image_tag @item.image ,class:"item-box-img" %>
-   
+          <%# 選択商品が売れて出品が無くなるとsold out表示 %>
+          <% if @item.order != nil %>
+            <div class='sold-out'>
+              <span>Sold Out!!</span>
+            </div>
+          <% end %>
       </div>
       <div class="item-price-box">
         <span class="item-price">
@@ -20,15 +26,15 @@
           <%= @item.postfee[:name] %>
         </span>
       </div>
+
     <% else %>
- 
     <% end %>
 
     <%# 商品が出品中 %>
     <% if @item.order == nil %>
       <%# ログイン中ユーザーと出品ユーザーが同一人物の場合、編集・購入ボタン表示有り %>
       <% if user_signed_in? && current_user.id == @item.user[:id] %>
-        <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+        <%= link_to "商品の編集", edit_item_path(@item) , method: :get, class: "item-red-btn" %>
         <p class="or-text">or</p>
         <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
       <%# ログイン中ユーザーと出品ユーザーが違う人物場合、購入ボタンのみ表示 %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -12,11 +12,11 @@
       <div class="item-img-content">
         <%= image_tag @item.image ,class:"item-box-img" %>
           <%# 選択商品が売れて出品が無くなるとsold out表示 %>
-          <% if @item.order != nil %>
-            <div class='sold-out'>
+          <%# <% if @item.order != nil %> 
+            <%# <div class='sold-out'>
               <span>Sold Out!!</span>
-            </div>
-          <% end %>
+            </div> %>
+          <%# <% end %> 
       </div>
       <div class="item-price-box">
         <span class="item-price">
@@ -31,7 +31,7 @@
     <% end %>
 
     <%# 商品が出品中 %>
-    <% if @item.order == nil %>
+    <%# <% if @item.order == nil %> 
       <%# ログイン中ユーザーと出品ユーザーが同一人物の場合、編集・購入ボタン表示有り %>
       <% if user_signed_in? && current_user.id == @item.user[:id] %>
         <%= link_to "商品の編集", edit_item_path(@item) , method: :get, class: "item-red-btn" %>
@@ -43,7 +43,7 @@
       <% else %>
         <%# ログアウト中は編集・削除・購入ボタン表示無し %>
       <% end %>
-    <% end %>
+    <%# <% end %> 
 
     <div class="item-explain-box">
       <span><%= @item.explain %></span>


### PR DESCRIPTION
#What
[furimaアプリのユーザーが選択した出品商品で変更が必要な時の編集]

#Why
furimaアプリを各ユーザーが出品中商品を選択した詳細ページから商品の変更が必要な編集ボタンによって、更新したいデータ情報に修正する為です。

■コードレビュー依頼<テックキャンプご指定送信：コードレビュー依頼フォーム(123期以降)>
メンターの方々へ、[最終課題:ユーザー管理機能https://github.com/https://github.com/https://github.com/https://github.com/https://github.com/Sugi-Hi/furima-39228/issues/8]におきまして、試行錯誤を繰り返した結果、一通りログイン中ユーザーが出品された商品詳細ページから編集ボタンにおけます編集ページに遷移し、必要なデータ情報の商品情報を編集できる機能は終えたとは思います。
動画におけまして、[ ログイン中の出品者が商品情報編集ページへ遷移できる動画]・[ 必要情報を適切な入力後「更新する」ボタンを押すと出品商品情報を編集できる動画]・[入力が問題で「変更する」ボタン押すと情報は未保存で編集ページに戻り、エラーメッセージ表示される動画]・[何も編集せず「更新する」ボタンを押しても画像無し商品にならない動画]・[ログイン中でも、URL直接入力自身とは違う出品者の商品情報編集ページ遷移すると、トップページに遷移する動画]・[ログイン中でもURL直接入力で自身が出品した売却済み商品情報編集ページへ遷移すると、トップページに遷移する動画]・[ ログアウト中URL直接入力で商品情報編集ページへ遷移すると、ログインページに遷移する動画]・[商品名・カテゴリー等カラム情報(ファイル以外)は、登録済みの商品情報編集画面を開くと、出品商品データ表示中動画]、計8種gyazo動画の添付URLを下記の様に記載させて頂きました。一度コードレビューの依頼をさせて頂きます。
・ログイン中の出品者が商品情報編集ページへ遷移できる動画
→https://gyazo.com/7271ea99363f96a38fcf020958353482

・ 必要情報を適切な入力後「更新する」ボタンを押すと、出品商品情報を編集できる動画
→https://gyazo.com/a529309952f7af6bd0543f590fcb1fcd

・入力が問題で「変更する」ボタン押すと情報は未保存で編集ページに戻り、エラーメッセージ表示される動画
→https://gyazo.com/f913169ea77f47627faac8ebae2ed619

・ 何も編集せず「更新する」ボタンを押しても画像無し商品にならない動画
→https://gyazo.com/5037c6b77676ac0ebba10c398b91516e

・ログイン中でもURL直接入力自身とは違う出品者の商品情報編集ページ遷移すると、トップページに遷移する動画
→https://gyazo.com/11bca529b517b949e4ea5d6733584218

・ログイン中でもURL直接入力で自身が出品した売却済み商品情報編集ページへ遷移すると、トップページに遷移する動画
→https://gyazo.com/b45b374b9fa55f27080338a6a2da611d

・ ログアウト中URL直接入力で商品情報編集ページへ遷移すると、ログインページに遷移する動画
→https://gyazo.com/ef43a67b486909c472d57d70b4eeec09

・商品名・カテゴリー等カラム情報(ファイル以外)は、登録済みの商品情報編集画面を開くと、出品商品データ表示中動画
→https://gyazo.com/dc71677e91510cd12fb34e1914874581

ご多忙の中大変恐縮ですが、コードレビューにおきましてご確認・ご回答頂けると大変ありがたいと思います。