### PR TITLE
商品削除機能の作成

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -36,11 +36,8 @@ class ItemsController < ApplicationController
   end
 
   def destroy
-    if @item.destroy
-      redirect_to root_path
-    else
-      render :show
-    end
+    @item.destroy
+    redirect_to root_path
   end
 
   def order

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
   before_action :set_item , except: [:index, :new, :create]
   before_action :authenticate_user!, except: [:index, :show]
   before_action :return_signin, only: [:new, :edit] 
-  before_action :another_top, only: [:edit ] 
+  before_action :another_top, only: [:edit, :destroy ] 
 
   def index
     @items = Item.all.order("created_at DESC")
@@ -35,8 +35,13 @@ class ItemsController < ApplicationController
     end
   end
 
-  # def destroy
-  # end
+  def destroy
+    if @item.destroy
+      redirect_to root_path
+    else
+      render :show
+    end
+  end
 
   def order
   end

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -36,7 +36,7 @@
       <% if user_signed_in? && current_user.id == @item.user[:id] %>
         <%= link_to "商品の編集", edit_item_path(@item) , method: :get, class: "item-red-btn" %>
         <p class="or-text">or</p>
-        <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+        <%= link_to "削除", item_path , method: :delete, class:"item-destroy" %>
       <%# ログイン中ユーザーと出品ユーザーが違う人物場合、購入ボタンのみ表示 %>
       <% elsif user_signed_in? && current_user.id != @item.user[:id]  %>
         <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>


### PR DESCRIPTION
#What
[furimaアプリのユーザーが不要になった出品商品の削除]

#Why
furimaアプリを各ユーザーが出品中商品を選択した詳細ページから、不要になったデータ情報を削除する為です。

■コードレビュー依頼<テックキャンプご指定送信：コードレビュー依頼フォーム(123期以降)>
メンターの方々へ、[最終課題:ユーザー管理機能https://github.com/https://github.com/https://github.com/https://github.com/https://github.com/https://github.com/Sugi-Hi/furima-39228/issues/9]におきまして、試行錯誤した結果、一通りログイン中ユーザーが出品された商品詳細ページから削除ボタンで、不要になったデータ情報・出品商品を削除できる機能は終えたとは思います。
動画におけまして、[ ログイン中の出品者のみが、商品詳細ページの削除ボタン押すと削除できる動画]のgyazo動画の添付URLを下記の様に記載させて頂きましたので、コードレビューの依頼をさせて頂きます。

・ログイン中の出品者のみが、商品詳細ページの削除ボタン押すと削除できる動画
https://gyazo.com/76e8bf3befdab58c360f894ff11cf39a

お忙しい中で大変恐縮ですが、コードレビューにおけましてご確認・ご回答など頂けると幸いです。